### PR TITLE
add order item field `channelSku`

### DIFF
--- a/src/Order/Model/Item.php
+++ b/src/Order/Model/Item.php
@@ -25,6 +25,11 @@ class Item
     /**
      * @var string
      */
+    protected $channelSku;
+
+    /**
+     * @var string
+     */
     protected $ean;
 
     /**
@@ -97,12 +102,30 @@ class Item
     }
 
     /**
+     * @return string|null
+     */
+    public function getChannelSku(): ?string
+    {
+        return $this->channelSku;
+    }
+
+    /**
      * @param string $sku
      * @return Item
      */
     public function setSku(string $sku): Item
     {
         $this->sku = $sku;
+        return $this;
+    }
+
+    /**
+     * @param string $channelSku
+     * @return Item
+     */
+    public function setChannelSku(string $channelSku): Item
+    {
+        $this->channelSku = $channelSku;
         return $this;
     }
 
@@ -229,6 +252,7 @@ class Item
             'quantity' => $this->getQuantity(),
             'billing_text' => $this->getBillingText(),
             'sku' => $this->getSku(),
+            'channel_sku' => $this->getChannelSku(),
             'transfer_price' => $this->getTransferPrice(),
         ];
     }

--- a/src/Order/Model/Order.php
+++ b/src/Order/Model/Order.php
@@ -636,6 +636,7 @@ class Order
                 $item->setId((int)$xmlItem->TB_ID);
                 $item->setChannelId((string)$xmlItem->CHANNEL_ID);
                 $item->setSku((string)$xmlItem->SKU);
+                $item->setChannelSku((string)$xmlItem->CHANNEL_SKU);
                 $item->setEan((string)$xmlItem->EAN);
                 $item->setQuantity((int)$xmlItem->QUANTITY);
                 $item->setBillingText((string)$xmlItem->BILLING_TEXT);

--- a/tests/Order/OrderTest.php
+++ b/tests/Order/OrderTest.php
@@ -78,6 +78,7 @@ class OrderTest extends Base
             ->setQuantity(10)
             ->setBillingText('article test')
             ->setSku('12345')
+            ->setChannelSku('54321')
             ->setChannelId('12345')
             ->setTransferPrice(50.0);
         $order->setItems([$item]);
@@ -181,6 +182,7 @@ class OrderTest extends Base
                     'quantity' => 10,
                     'billing_text' => 'article test',
                     'sku' => '12345',
+                    'channel_sku' => '54321',
                     'transfer_price' => 50.0
                 ]
             ],


### PR DESCRIPTION
The field `CHANNEL_SKU` is missing, see https://www.tradebyte.io/documentation/structure-of-an-order-in-tb-order-format/order-items-item/